### PR TITLE
Jobutil Updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="tdutils",
-    version="0.0.2",
+    version="0.0.3",
     author="City of Austin",
     author_email="transportation.data@austintexas.gov",
     description="Various utilities for managing and pulishing transportation data.",

--- a/tdutils/jobutil.py
+++ b/tdutils/jobutil.py
@@ -56,9 +56,9 @@ class Job(object):
         res = self._query("SELECT", url)
 
         try:
-            return arrow.get(res[0][self.end_date_field]).timestamp
+            return arrow.get(res[0][self.start_date_field]).timestamp
 
-        except IndexError:
+        except (IndexError, KeyError) as e:
             return None
 
     def start(self):


### PR DESCRIPTION
The most_recent() method now uses start_date of the previous successful job run, rather than end_date. Obviously an important distinction, since this ensures that any records that are created or modified in the source database between the start and end of the job run will be included in the next run.